### PR TITLE
Provide built-in yeast example

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ WORKDIR /chado/chado/
 
 RUN perl Makefile.PL GMOD_ROOT=/usr/share/gmod/  DEFAULTS=1 RECONFIGURE=1 && make && make install
 
-ENV SCHEMA_URL=https://github.com/erasche/chado-schema-builder/releases/download/1.31-jenkins95/chado-1.31.sql.gz \
+ENV SCHEMA_URL=https://github.com/erasche/chado-schema-builder/releases/download/1.31-jenkins97/chado-1.31.sql.gz \
     INSTALL_CHADO_SCHEMA=1 \
     INSTALL_YEAST_DATA=0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,32 +35,32 @@ ENV CHADO_DB_NAME=postgres \
 
 RUN mkdir -p $GMOD_ROOT $PGDATA && \
     curl -L http://cpanmin.us | perl - App::cpanminus && \
-    cpanm --force --notest Test::More Heap::Simple Heap::Simple::XS DBIx::DBStag GO::Parser
-
-RUN cpanm --notest DBI Digest::Crc32 Cache::Ref::FIFO URI::Escape HTML::Entities \
+    cpanm --force --notest Test::More Heap::Simple Heap::Simple::XS DBIx::DBStag GO::Parser && \
+    cpanm --notest DBI Digest::Crc32 Cache::Ref::FIFO URI::Escape HTML::Entities \
     HTML::HeadParser HTML::TableExtract HTTP::Request::Common LWP XML::Parser \
     XML::Parser::PerlSAX XML::SAX::Writer XML::Simple Data::Stag \
-    Error PostScript::TextBlock Spreadsheet::ParseExcel Algorithm::Munkres
-
-RUN cpanm --notest CJFIELDS/BioPerl-1.6.924.tar.gz Bio::GFF3::LowLevel::Parser File::Next CGI DBD::Pg SQL::Translator \
+    Error PostScript::TextBlock Spreadsheet::ParseExcel Algorithm::Munkres \
+    CJFIELDS/BioPerl-1.6.924.tar.gz Bio::GFF3::LowLevel::Parser File::Next CGI DBD::Pg SQL::Translator \
     Digest::MD5 Text::Shellwords Module::Build Class::DBI Class::DBI::Pg \
     Class::DBI::Pager Template Bio::Chado::Schema GD GO::Parser Bio::FeatureIO
-
 
 RUN wget https://github.com/GMOD/Chado/archive/master.tar.gz -O /tmp/master.tar.gz \
     && cd / && tar xvfz /tmp/master.tar.gz \
     && mv /Chado-master /chado && rm /tmp/master.tar.gz
-WORKDIR /chado//chado/
+
+WORKDIR /chado/chado/
+
 RUN perl Makefile.PL GMOD_ROOT=/usr/share/gmod/  DEFAULTS=1 RECONFIGURE=1 && make && make install
 
 ENV SCHEMA_URL=https://github.com/erasche/chado-schema-builder/releases/download/1.31-jenkins95/chado-1.31.sql.gz \
     INSTALL_CHADO_SCHEMA=1 \
     INSTALL_YEAST_DATA=0
+
 # https://github.com/docker-library/postgres/blob/a82c28e1c407ef5ddfc2a6014dac87bcc4955a26/9.4/docker-entrypoint.sh#L85
 # This will cause the chado schema to load on boot and be MUCH better behaved.
 RUN wget --quiet $SCHEMA_URL -O /chado.sql.gz && gunzip /chado.sql.gz && \
-	wget --quiet http://downloads.yeastgenome.org/curation/chromosomal_feature/saccharomyces_cerevisiae.gff && \
-	sed -i s'/%20/ /g' saccharomyces_cerevisiae.gff
+    wget --quiet http://downloads.yeastgenome.org/curation/chromosomal_feature/saccharomyces_cerevisiae.gff && \
+    sed -i s'/%20/ /g' saccharomyces_cerevisiae.gff
 
 COPY load_schema.sh /docker-entrypoint-initdb.d/load_schema.sh
 COPY load_yeast.sh /docker-entrypoint-initdb.d/load_yeast.sh

--- a/README.md
+++ b/README.md
@@ -47,3 +47,12 @@ docker run -d --name chado-tools -e INSTALL_CHADO_SCHEMA=0 erasche/chado
 
 This will let you use all the GMOD tools without needing to wait for the chado
 schema to install.
+
+## Yeasty Container
+
+If you would like some default yeast data installed for you, you can supply the
+environment variable `INSTALL_YEAST_DATA=1`. This requires that you leave `INSTALL_CHADO_SCHEMA=1`:
+
+```console
+docker run -d --name chado-yeast -e INSTALL_YEAST_DATA=1 erasche/chado
+```

--- a/load_yeast.sh
+++ b/load_yeast.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+: ${INSTALL_YEAST_DATA:=1}
+if [[ $INSTALL_YEAST_DATA -eq 1 ]]; then
+	gmod_add_organism.pl --genus Saccharomyces --species cerevisiae --common_name yeast --comment '' --abbreviation 's.cer';
+
+	gmod_gff3_preprocessor.pl --gff saccharomyces_cerevisiae.gff --nosplit --hasref && \
+	cat saccharomyces_cerevisiae.gff.sorted > yeast.gff && \
+	echo "##FASTA" >> yeast.gff && \
+	cat saccharomyces_cerevisiae.gff.sorted.fasta >> yeast.gff && \
+
+	# Cleanup GFF3 file
+	sed -i 's/dbxref=NCBI:;//g' yeast.gff && \
+	sed -i '/ARS_consensus_sequence/d' yeast.gff && \
+	sed -i '/silent_mating_type_cassette_array/d' yeast.gff && \
+	sed -i '/Y_region/d' yeast.gff && \
+	sed -i '/W_region/d' yeast.gff && \
+	sed -i '/Z1_region/d' yeast.gff && \
+	sed -i '/X_region/d' yeast.gff && \
+	sed -i '/Z2_region/d' yeast.gff && \
+	sed -i '/intein_encoding_region/d' yeast.gff && \
+
+	gmod_bulk_load_gff3.pl --organism yeast -g yeast.gff --recreate
+fi


### PR DESCRIPTION
I was working on https://github.com/erasche/chado-jbrowse-connector/issues/5, but I hit https://github.com/erasche/chado-schema-builder/issues/7 which is blocking merging this.

With this, we have (optionally loaded) Yeast data built into the container which is excellent for users who just want to play with Chado.