### PR TITLE
Fix startup error when INSTALL_CHADO_SCHEMA == 0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,4 +58,5 @@ RUN perl Makefile.PL GMOD_ROOT=/usr/share/gmod/  DEFAULTS=1 RECONFIGURE=1 && \
 
 COPY load_schema.sh /docker-entrypoint-initdb.d/00-load_schema.sh
 COPY load_yeast.sh /docker-entrypoint-initdb.d/01-load_yeast.sh
-COPY search.sql /docker-entrypoint-initdb.d/02-search.sql
+COPY search.sh /docker-entrypoint-initdb.d/02-search.sh
+COPY search.sql /search.sql

--- a/search.sh
+++ b/search.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+: ${INSTALL_CHADO_SCHEMA:=1}
+if [[ $INSTALL_CHADO_SCHEMA -eq 1 ]]; then
+    psql --username postgres --dbname "$POSTGRES_DB" < /search.sql
+fi


### PR DESCRIPTION
Hi,
Just a little fix for an error at startup when INSTALL_CHADO_SCHEMA is set to 0 (it tried to load the sql file while the db was empty)